### PR TITLE
灰度逻辑支持百分比灰度和指定用户灰度共存

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -195,9 +195,8 @@ func JsonToGrayConfig(json gjson.Result, grayConfig *GrayConfig) error {
 			Weight:            weight,
 			VersionPredicates: convertToStringMap(item.Get("versionPredicates")),
 		})
-		if weight > 0 {
+		if weight > 0 && grayConfig.GrayWeight == 0 {
 			grayConfig.GrayWeight = weight
-			break
 		}
 	}
 

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -52,14 +52,18 @@ static_resources:
                                 "uniqueGrayTag": "uuid",
                                 "rules": [
                                   {
-                                    "name": "inner-user",
-                                    "grayKeyValue": [
-                                      "00000001",
-                                      "00000005"
-                                    ]
+                                    "name": "inner-user"
                                   },
                                   {
                                     "name": "beta-user",
+                                    "grayTagKey": "level",
+                                    "grayTagValue": [
+                                      "level3",
+                                      "level5"
+                                    ]
+                                  },
+                                  {
+                                    "name": "inner-user1",
                                     "grayKeyValue": [
                                       "noah",
                                       "00000003"
@@ -72,9 +76,9 @@ static_resources:
                                   }
                                 ],
                                 "rewrite": {
-                                  "host": "apig-oss-integration.oss-cn-hangzhou.aliyuncs.com",
+                                  "host": "static.chagee.com",
                                   "indexRouting": {
-                                    "/": "/mfe/{version}/index.html"
+                                    "/": "/mfe/chagee-iot-operation/{version}/index.html"
                                   },
                                   "fileRouting": {
                                     "/": "/mfe/{version}",
@@ -89,18 +93,28 @@ static_resources:
                                   "/mfe/**/mf-manifest-main.json"
                                 ],
                                 "baseDeployment": {
-                                  "version": "v1"
+                                  "version": "test"
                                 },
                                 "grayDeployments": [
                                   {
-                                    "weight": 90,
-                                    "name": "beta-user",
-                                    "version": "v2",
+                                    "weight": 30,
+                                    "name": "inner-user",
+                                    "version": "uat",
                                     "enabled": true,
-                                    "backendVersion":"gray",
-                                    "versionPredicates": {
-                                      "/mfe": "v1"
-                                    }
+                                    "backendVersion":"gray1"
+                                  },
+                                  {
+                                    "weight": 30,
+                                    "name": "beta-user",
+                                    "version": "prod",
+                                    "enabled": true,
+                                    "backendVersion":"gray2"
+                                  },
+                                  {
+                                    "name": "inner-user1",
+                                    "version": "uat",
+                                    "enabled": true,
+                                    "backendVersion":"gray3"
                                   }
                                 ],
                                 "injection": {
@@ -141,5 +155,5 @@ static_resources:
               - endpoint:
                   address:
                     socket_address:
-                      address: apig-oss-integration.oss-cn-hangzhou.aliyuncs.com
+                      address: static.chagee.com
                       port_value: 80

--- a/main.go
+++ b/main.go
@@ -72,18 +72,17 @@ func onHttpRequestHeaders(ctx wrapper.HttpContext, grayConfig config.GrayConfig)
 	_ = proxywasm.RemoveHttpRequestHeader("Content-Length")
 	deployment := &config.Deployment{}
 
-	  // 处理cookie首次加载为空的情况
-    var effectiveCookie string
-    if cookie == "" {
-        uniqueId, isUniqueIdOk := ctx.GetContext(grayConfig.UniqueGrayTag).(string)
-        if isUniqueIdOk {
-            // 构造一个包含 uniqueId 的虚拟 cookie
-            effectiveCookie = fmt.Sprintf("%s=%s", grayConfig.UniqueGrayTag, uniqueId)
-        }
-    } else {
-        effectiveCookie = cookie
-    }
-
+	// 处理cookie首次加载为空的情况
+  var effectiveCookie string
+  if cookie == "" {
+      uniqueId, isUniqueIdOk := ctx.GetContext(grayConfig.UniqueGrayTag).(string)
+      if isUniqueIdOk {
+          // 构造一个包含 uniqueId 的虚拟 cookie
+          effectiveCookie = fmt.Sprintf("%s=%s", grayConfig.UniqueGrayTag, uniqueId)
+      }
+  } else {
+      effectiveCookie = cookie
+  }
 	log.Infof("effectiveCookie: %s", effectiveCookie)
 
 	globalConfig := grayConfig.Injection.GlobalConfig

--- a/main.go
+++ b/main.go
@@ -72,25 +72,39 @@ func onHttpRequestHeaders(ctx wrapper.HttpContext, grayConfig config.GrayConfig)
 	_ = proxywasm.RemoveHttpRequestHeader("Content-Length")
 	deployment := &config.Deployment{}
 
+	  // 处理cookie首次加载为空的情况
+    var effectiveCookie string
+    if cookie == "" {
+        uniqueId, isUniqueIdOk := ctx.GetContext(grayConfig.UniqueGrayTag).(string)
+        if isUniqueIdOk {
+            // 构造一个包含 uniqueId 的虚拟 cookie
+            effectiveCookie = fmt.Sprintf("%s=%s", grayConfig.UniqueGrayTag, uniqueId)
+        }
+    } else {
+        effectiveCookie = cookie
+    }
+
+	log.Infof("effectiveCookie: %s", effectiveCookie)
+
 	globalConfig := grayConfig.Injection.GlobalConfig
 	if globalConfig.Enabled {
-		conditionRule := util.GetConditionRules(grayConfig.Rules, grayKeyValue, cookie)
+		conditionRule := util.GetConditionRules(grayConfig.Rules, grayKeyValue, effectiveCookie)
 		trimmedValue := strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(globalConfig.Value), "{"), "}")
 		ctx.SetContext(globalConfig.Key, fmt.Sprintf("<script>var %s = {\n%s:%s,\n %s \n}\n</script>", globalConfig.Key, globalConfig.FeatureKey, conditionRule, trimmedValue))
 	}
 
 	if isHtmlRequest {
 		// index首页请求每次都会进度灰度规则判断
-		deployment = util.FilterGrayRule(&grayConfig, grayKeyValue, cookie)
+		deployment = util.FilterGrayRule(&grayConfig, grayKeyValue, effectiveCookie)
 		log.Infof("route: %s, index html request: %v, backend: %v, xPreHigressVersion: %s", route, requestPath, deployment.BackendVersion, frontendVersion)
 		ctx.SetContext(config.PreHigressVersion, deployment.Version)
 		ctx.SetContext(grayConfig.BackendGrayTag, deployment.BackendVersion)
 	} else {
 		if util.IsSupportMultiVersion(grayConfig) {
-			deployment = util.FilterMultiVersionGrayRule(&grayConfig, grayKeyValue, cookie, requestPath)
+			deployment = util.FilterMultiVersionGrayRule(&grayConfig, grayKeyValue, effectiveCookie, requestPath)
 			log.Infof("route: %s, multi version %v", route, deployment)
 		} else {
-			grayDeployment := util.FilterGrayRule(&grayConfig, grayKeyValue, cookie)
+			grayDeployment := util.FilterGrayRule(&grayConfig, grayKeyValue, effectiveCookie)
 			if isIndexRequest {
 				deployment = grayDeployment
 			} else {
@@ -180,7 +194,7 @@ func onHttpResponseHeader(ctx wrapper.HttpContext, grayConfig config.GrayConfig)
 	proxywasm.ReplaceHttpResponseHeader("cache-control", "no-cache, no-store, max-age=0, must-revalidate")
 
 	// 构建Cookie属性
-	cookieAttributes := fmt.Sprintf("Max-Age=%d; Path=/; HttpOnly; Secure", grayConfig.StoreMaxAge)
+	cookieAttributes := fmt.Sprintf("Max-Age=%d; Path=/; Secure", grayConfig.StoreMaxAge)
 	if grayConfig.CookieDomain != "" {
 		cookieAttributes += fmt.Sprintf("; Domain=%s", grayConfig.CookieDomain)
 	}
@@ -203,7 +217,7 @@ func onHttpResponseHeader(ctx wrapper.HttpContext, grayConfig config.GrayConfig)
 		if isBackVersionOk {
 			if backendVersion == "" {
 				// 删除后端灰度版本
-				expireCookieAttr := "Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; HttpOnly; Secure"
+				expireCookieAttr := "Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure"
 				if grayConfig.CookieDomain != "" {
 					expireCookieAttr += fmt.Sprintf("; Domain=%s", grayConfig.CookieDomain)
 				}


### PR DESCRIPTION
1、修复 Cookie 为空时，上下文 UniqueID 与参与百分比灰度 UniqueID 不一致问题
2、FilterGrayRule 百分比灰度规则中调整 uniqueId 获取逻辑，优先🍪 Cookie 取 GrayTagKey 值，如果没有则取UniqueGrayTag
3、可以设置多个百分比灰度规则，百分比灰度规则如果没有设置grayTagKey，默认使用UniqueGrayTag作为灰度key；支持百分比灰度和指定id灰度共存
3、移除cookie的httpOnly属性